### PR TITLE
fix(php84): explicit nullable types + add CI/release workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify composer.json version matches tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          COMPOSER_VERSION=$(php -r 'echo json_decode(file_get_contents("composer.json"))->version;')
+          if [ "$TAG" != "$COMPOSER_VERSION" ]; then
+            echo "Tag $TAG does not match composer.json version $COMPOSER_VERSION"
+            exit 1
+          fi
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 "${GITHUB_REF}^" 2>/dev/null || echo "")
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:'- %s (%h)' "$PREV_TAG..${GITHUB_REF}")
+          else
+            NOTES=$(git log --pretty=format:'- %s (%h)' "${GITHUB_REF}")
+          fi
+          {
+            echo 'notes<<EOF'
+            echo "$NOTES"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.notes.outputs.notes }}
+          draft: false
+          prerelease: false
+
+      - name: Notify Packagist
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_TOKEN: ${{ secrets.PACKAGIST_TOKEN }}
+        run: |
+          if [ -z "$PACKAGIST_USERNAME" ] || [ -z "$PACKAGIST_TOKEN" ]; then
+            echo "Packagist credentials not configured; skipping notification."
+            exit 0
+          fi
+          curl -fsS -XPOST -H'content-type:application/json' \
+            "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_TOKEN}" \
+            -d'{"repository":{"url":"https://github.com/${{ github.repository }}"}}'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4']
+        laravel: ['10.*', '11.*', '12.*']
+        exclude:
+          - php: '8.2'
+            laravel: '12.*'
+
+    name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/pest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "league/commonmark": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0",
-        "phpunit/phpunit": "^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "phpunit/phpunit": "^10.0|^11.0",
         "pestphp/pest": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "uglydawg/laravel-markdown-emails",
     "description": "A Laravel package for generating emails using Markdown with dynamic content support",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "type": "library",
     "keywords": [
         "laravel",

--- a/src/MarkdownEmailRenderer.php
+++ b/src/MarkdownEmailRenderer.php
@@ -63,7 +63,7 @@ class MarkdownEmailRenderer
     /**
      * Render markdown content to HTML email
      */
-    public function render(string $markdown, array $variables = [], string $template = null): string
+    public function render(string $markdown, array $variables = [], ?string $template = null): string
     {
         try {
             // Validate that all variables in markdown are provided
@@ -155,7 +155,7 @@ class MarkdownEmailRenderer
     /**
      * Create and optionally store a markdown email
      */
-    public function create(string $subject, string $markdown, array $recipients, array $variables = [], string $template = null): MarkdownEmail
+    public function create(string $subject, string $markdown, array $recipients, array $variables = [], ?string $template = null): MarkdownEmail
     {
         $htmlContent = $this->render($markdown, $variables, $template);
         


### PR DESCRIPTION
## Summary
- PHP 8.4 deprecates implicit nullable parameter types (`string $foo = null` → `?string $foo = null`)
- Fix on `MarkdownEmailRenderer::render()` and `::create()` for `$template` param
- Bump `composer.json` version to `1.0.1`
- Add CI workflow: PHP 8.2/8.3/8.4 × Laravel 10/11/12 matrix
- Add release workflow: auto GitHub Release + optional Packagist notify on `v*.*.*` tag
- Add Dependabot config: weekly composer + github-actions updates

## Test plan
- [ ] tests.yml workflow run passes on all matrix combos
- [ ] After merge + tag `v1.0.1` push: release.yml creates GitHub Release
- [ ] Consumers on PHP 8.4 no longer see `Implicitly marking parameter as nullable` deprecation