### PR TITLE
feat: add Laravel 13 support (v1.0.2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,10 +16,12 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4']
-        laravel: ['10.*', '11.*', '12.*']
+        laravel: ['10.*', '11.*', '12.*', '13.*']
         exclude:
           - php: '8.2'
             laravel: '12.*'
+          - php: '8.2'
+            laravel: '13.*'
 
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }}
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "uglydawg/laravel-markdown-emails",
     "description": "A Laravel package for generating emails using Markdown with dynamic content support",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "type": "library",
     "keywords": [
         "laravel",
@@ -18,13 +18,13 @@
     ],
     "require": {
         "php": "^8.1",
-        "illuminate/support": "^10.0|^11.0|^12.0",
-        "illuminate/mail": "^10.0|^11.0|^12.0",
-        "illuminate/database": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/mail": "^10.0|^11.0|^12.0|^13.0",
+        "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "league/commonmark": "^2.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.0|^9.0|^10.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.0|^11.0",
         "pestphp/pest": "*"
     },


### PR DESCRIPTION
## Summary
Widens framework constraints to support Laravel 13.

- `illuminate/{support,mail,database}`: add `^13.0`
- `orchestra/testbench` dev: add `^11.0` (Laravel 13 testbench line)
- CI matrix: add Laravel `13.*` (PHP 8.3+ only — Laravel 13 dropped PHP 8.2)
- Version: `1.0.1` → `1.0.2`

Required by downstream consumers on Laravel 13.

## Test plan
- [ ] All matrix combos pass (PHP 8.2 × L10/L11; PHP 8.3/8.4 × L10/L11/L12/L13)
- [ ] After merge + `v1.0.2` tag: release.yml creates GitHub Release