### PR TITLE
ci(dependabot): ignore phpunit/phpunit updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - dependencies
+    ignore:
+      # phpunit is a dev-only dependency; cc-api consumers ship their own
+      # phpunit lockfile and run their own audits. Dependabot security
+      # updates here fail to resolve because the pkg supports multiple
+      # Laravel major versions simultaneously, which leaves dependabot
+      # unable to pick a single lockfile state.
+      - dependency-name: phpunit/phpunit
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Dependabot security updates for phpunit fail to resolve because the pkg supports L10/11/12/13 simultaneously — no single lockfile state exists for the resolver. cc-consulting-nv saw the failure on run 25745943167. Consumers ship their own lockfile + audits, so phpunit security here is moot.